### PR TITLE
feat: llm-friendly

### DIFF
--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,0 +1,10 @@
+import { source } from '@/lib/source';
+import type { InferPageType } from 'fumadocs-core/source';
+
+export async function getLLMText(page: InferPageType<typeof source>) {
+    const processed = await page.data.getText('processed');
+
+    return `# ${page.data.title} (${page.url})
+
+${processed}`;
+}

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,10 +1,10 @@
-import { source } from '@/lib/source';
-import type { InferPageType } from 'fumadocs-core/source';
+import type { InferPageType } from "fumadocs-core/source";
+import type { source } from "@/lib/source";
 
 export async function getLLMText(page: InferPageType<typeof source>) {
-    const processed = await page.data.getText('processed');
+  const processed = await page.data.getText("processed");
 
-    return `# ${page.data.title} (${page.url})
+  return `# ${page.data.title} (${page.url})
 
 ${processed}`;
 }

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isMarkdownPreferred, rewritePath } from 'fumadocs-core/negotiation';
+
+const { rewrite: rewriteLLM } = rewritePath('/docs{/*path}', '/llms.mdx/docs{/*path}');
+
+export default function proxy(request: NextRequest) {
+    if (isMarkdownPreferred(request)) {
+        const result = rewriteLLM(request.nextUrl.pathname);
+
+        if (result) {
+            return NextResponse.rewrite(new URL(result, request.nextUrl));
+        }
+    }
+
+    return NextResponse.next();
+}

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -1,16 +1,19 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { isMarkdownPreferred, rewritePath } from 'fumadocs-core/negotiation';
+import { isMarkdownPreferred, rewritePath } from "fumadocs-core/negotiation";
+import { type NextRequest, NextResponse } from "next/server";
 
-const { rewrite: rewriteLLM } = rewritePath('/docs{/*path}', '/llms.mdx/docs{/*path}');
+const { rewrite: rewriteLLM } = rewritePath(
+  "/docs{/*path}",
+  "/llms.mdx/docs{/*path}",
+);
 
 export default function proxy(request: NextRequest) {
-    if (isMarkdownPreferred(request)) {
-        const result = rewriteLLM(request.nextUrl.pathname);
+  if (isMarkdownPreferred(request)) {
+    const result = rewriteLLM(request.nextUrl.pathname);
 
-        if (result) {
-            return NextResponse.rewrite(new URL(result, request.nextUrl));
-        }
+    if (result) {
+      return NextResponse.rewrite(new URL(result, request.nextUrl));
     }
+  }
 
-    return NextResponse.next();
+  return NextResponse.next();
 }

--- a/bun.lock
+++ b/bun.lock
@@ -472,7 +472,7 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
-    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -602,7 +602,7 @@
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 

--- a/packages/seox/docs/README.md
+++ b/packages/seox/docs/README.md
@@ -1,0 +1,28 @@
+# seox
+
+> Simplified SEO management for Next.js App Router
+
+seox is an open-source library that centralizes SEO (meta tags, Open Graph, Twitter Cards, JSON-LD) in Next.js App Router projects via a single TypeScript configuration.
+
+## Package exports
+
+| Import path | Exports | Purpose |
+|-------------|---------|---------|
+| `seox` | `SEOConfig`, `SEOJsonLd` (types only) | Type definitions for configuration |
+| `seox/next` | `Seox`, `JsonLd`, `SEOConfig`, `SEOJsonLd` | Runtime class + React component for Next.js |
+
+## Documentation files
+
+| File | Contents |
+|------|----------|
+| [getting-started.md](./getting-started.md) | Installation, setup, basic usage |
+| [api-reference.md](./api-reference.md) | Complete API: types, `Seox` class, `JsonLd` component |
+| [cli.md](./cli.md) | CLI commands: `init`, `configure`, `doctor` |
+| [examples.md](./examples.md) | Common patterns and recipes |
+
+## Requirements
+
+- Node.js >= 18.0.0
+- Next.js >= 14.0.0
+- React >= 18.0.0
+- TypeScript >= 5.0.0

--- a/packages/seox/docs/api-reference.md
+++ b/packages/seox/docs/api-reference.md
@@ -1,0 +1,123 @@
+# API Reference
+
+## Types
+
+### `SEOConfig`
+
+```ts
+import type { SEOConfig } from "seox";
+```
+
+Extends Next.js `Metadata` with three additional fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | Yes | Site name. Used as fallback for `openGraph.siteName`. |
+| `url` | `string` | Yes | Site URL. Used as fallback for `openGraph.url`. |
+| `jsonld` | `SEOJsonLd[]` | No | Array of JSON-LD structured data schemas. |
+
+All standard Next.js `Metadata` fields are also accepted: `title`, `description`, `keywords`, `authors`, `creator`, `publisher`, `openGraph`, `twitter`, `robots`, `alternates`, `metadataBase`, `icons`, `manifest`, etc.
+
+### `SEOJsonLd`
+
+```ts
+import type { SEOJsonLd } from "seox";
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `@context` | `string` | Yes | Schema context, typically `"https://schema.org"`. |
+| `@type` | `string` | Yes | Schema.org type (e.g. `"Organization"`, `"WebSite"`, `"FAQPage"`). |
+| `[key: string]` | `unknown` | No | Any additional Schema.org properties. |
+
+---
+
+## `Seox` class
+
+```ts
+import { Seox } from "seox/next";
+```
+
+### Constructor
+
+```ts
+const seo = new Seox(config: SEOConfig);
+```
+
+Creates a new Seox instance. The `config` object is stored and used as the base for all metadata generation.
+
+### `seo.config`
+
+```ts
+seo.config: SEOConfig
+```
+
+Public property. Direct access to the underlying configuration object.
+
+### `seo.configToMetadata(overrides?)`
+
+```ts
+seo.configToMetadata(overrides?: Partial<SEOConfig>): Metadata
+```
+
+Returns a Next.js `Metadata` object by merging the base config with optional overrides.
+
+Behavior:
+- Strips `name`, `url`, and `jsonld` from the output (these are not valid Next.js Metadata fields).
+- Spreads base metadata, then override metadata on top.
+- If `openGraph` exists in either base or overrides, applies fallbacks: `openGraph.url` defaults to `config.url`, `openGraph.siteName` defaults to `config.name`.
+
+Use this as the value of `export const metadata` or return it from `generateMetadata()` in any Next.js page or layout.
+
+### `seo.generatePageMetadata(overrides?)`
+
+```ts
+seo.generatePageMetadata(overrides?: Partial<SEOConfig>): Metadata
+```
+
+Alias for `configToMetadata()`. Identical behavior.
+
+### `seo.getJsonLd(overrides?)`
+
+```ts
+seo.getJsonLd(overrides?: SEOJsonLd[]): SEOJsonLd[]
+```
+
+Returns the combined array of JSON-LD schemas: base schemas from `config.jsonld` concatenated with `overrides`.
+
+### `seo.getJsonLdStrings(overrides?)`
+
+```ts
+seo.getJsonLdStrings(overrides?: SEOJsonLd[]): string[]
+```
+
+Same as `getJsonLd()` but returns each schema as a `JSON.stringify()`-ed string, ready for injection into `<script>` tags.
+
+---
+
+## `JsonLd` component
+
+```tsx
+import { JsonLd } from "seox/next";
+```
+
+React server component that renders `<script type="application/ld+json">` tags.
+
+### Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `seo` | `Seox` | Yes | Your Seox instance. Schemas are read from `seo.getJsonLd()`. |
+| `additionalSchemas` | `SEOJsonLd[]` | No | Extra schemas to append (page-specific structured data). |
+
+### Usage
+
+```tsx
+// In layout.tsx <head> — renders all global schemas
+<JsonLd seo={seoConfig} />
+
+// In a specific page — adds page-specific schemas alongside global ones
+<JsonLd seo={seoConfig} additionalSchemas={[productSchema]} />
+```
+
+Returns `null` if no schemas are configured.

--- a/packages/seox/docs/cli.md
+++ b/packages/seox/docs/cli.md
@@ -1,0 +1,62 @@
+# CLI Reference
+
+All commands are available via `bunx seox` or `npx seox`.
+
+## `seox init`
+
+Creates a `lib/seo.ts` configuration file with interactive prompts.
+
+```bash
+bunx seox init
+```
+
+Prompts for:
+- **Site name** — used for `name` and `title.default`
+- **Base URL** — used for `url`
+- **Description** — used for `description`
+
+If a `src/` directory exists, the file is created at `src/lib/seo.ts` instead.
+
+The generated file imports `Seox` from `seox/next` and exports a configured `seoConfig` instance with a scaffolded JSON-LD Organization schema.
+
+## `seox configure`
+
+Scans your Next.js project and injects SEO metadata into layout and page files.
+
+```bash
+bunx seox configure [options]
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Overwrite existing metadata exports |
+| `--validate` | Only validate, do not modify files |
+
+### What it does
+
+1. Verifies `lib/seo.ts` (or `src/lib/seo.ts`) exists.
+2. Scans `app/` directory for `layout.tsx` and `page.tsx` files.
+3. For each layout file: adds `export const metadata = seoConfig.configToMetadata()` and the `<JsonLd />` component.
+4. For each page file: adds `export const metadata = seoConfig.configToMetadata()`.
+5. Skips files that already have metadata exports (unless `--force`).
+
+## `seox doctor`
+
+Validates your SEO configuration for common issues.
+
+```bash
+bunx seox doctor
+```
+
+### Checks performed
+
+- Configuration file exists at expected path
+- `name` is defined and non-empty
+- `url` is a valid URL
+- `title` is configured
+- `description` is configured and reasonable length
+- JSON-LD schemas have valid `@context` and `@type`
+
+Reports a summary of passed checks, warnings, and errors.

--- a/packages/seox/docs/examples.md
+++ b/packages/seox/docs/examples.md
@@ -1,0 +1,251 @@
+# Examples
+
+## Basic blog setup
+
+```ts
+// lib/seo.ts
+import { Seox } from "seox/next";
+
+export const seoConfig = new Seox({
+  name: "My Blog",
+  url: "https://myblog.com",
+  metadataBase: new URL("https://myblog.com"),
+  title: {
+    default: "My Blog",
+    template: "%s | My Blog",
+  },
+  description: "Thoughts on web development",
+  keywords: ["blog", "web development", "javascript"],
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "My Blog",
+  },
+  twitter: {
+    card: "summary_large_image",
+    creator: "@handle",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  jsonld: [
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "My Blog",
+      url: "https://myblog.com",
+    },
+  ],
+});
+```
+
+## Root layout with JSON-LD
+
+```tsx
+// app/layout.tsx
+import { seoConfig } from "@/lib/seo";
+import { JsonLd } from "seox/next";
+
+export const metadata = seoConfig.configToMetadata();
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <JsonLd seo={seoConfig} />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+## Static page metadata
+
+```tsx
+// app/about/page.tsx
+import { seoConfig } from "@/lib/seo";
+
+export const metadata = seoConfig.configToMetadata({
+  title: "About",
+  description: "About our team and mission",
+});
+
+export default function AboutPage() {
+  return <main>About page content</main>;
+}
+```
+
+## Dynamic metadata with `generateMetadata`
+
+```tsx
+// app/blog/[slug]/page.tsx
+import type { Metadata } from "next";
+import { seoConfig } from "@/lib/seo";
+
+type Props = { params: Promise<{ slug: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getPost(slug);
+
+  return seoConfig.configToMetadata({
+    title: post.title,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: "article",
+      images: [{ url: post.coverImage }],
+    },
+  });
+}
+
+export default async function BlogPost({ params }: Props) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+  return <article>{post.content}</article>;
+}
+```
+
+## Page-specific JSON-LD
+
+```tsx
+// app/blog/[slug]/page.tsx
+import { seoConfig } from "@/lib/seo";
+import { JsonLd } from "seox/next";
+
+export default async function BlogPost({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+
+  const articleSchema = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: post.title,
+    description: post.excerpt,
+    author: { "@type": "Person", name: post.author },
+    datePublished: post.publishedAt,
+    image: post.coverImage,
+  };
+
+  return (
+    <>
+      <JsonLd seo={seoConfig} additionalSchemas={[articleSchema]} />
+      <article>{post.content}</article>
+    </>
+  );
+}
+```
+
+## E-commerce product page
+
+```tsx
+// app/products/[id]/page.tsx
+import type { Metadata } from "next";
+import { seoConfig } from "@/lib/seo";
+import { JsonLd } from "seox/next";
+
+type Props = { params: Promise<{ id: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const product = await getProduct(id);
+
+  return seoConfig.configToMetadata({
+    title: product.name,
+    description: product.description,
+    openGraph: {
+      title: product.name,
+      description: product.description,
+      images: product.images.map((url) => ({ url })),
+    },
+  });
+}
+
+export default async function ProductPage({ params }: Props) {
+  const { id } = await params;
+  const product = await getProduct(id);
+
+  const productSchema = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: product.name,
+    description: product.description,
+    image: product.images,
+    offers: {
+      "@type": "Offer",
+      price: product.price,
+      priceCurrency: "USD",
+      availability: "https://schema.org/InStock",
+    },
+  };
+
+  return (
+    <>
+      <JsonLd seo={seoConfig} additionalSchemas={[productSchema]} />
+      <main>{/* product UI */}</main>
+    </>
+  );
+}
+```
+
+## FAQ page with structured data
+
+```tsx
+// app/faq/page.tsx
+import { seoConfig } from "@/lib/seo";
+import { JsonLd } from "seox/next";
+
+const faqs = [
+  { question: "What is seox?", answer: "A SEO library for Next.js App Router." },
+  { question: "Does it support JSON-LD?", answer: "Yes, via the JsonLd component and config." },
+];
+
+export const metadata = seoConfig.configToMetadata({
+  title: "FAQ",
+  description: "Frequently asked questions",
+});
+
+export default function FAQPage() {
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  };
+
+  return (
+    <>
+      <JsonLd seo={seoConfig} additionalSchemas={[faqSchema]} />
+      <main>
+        {faqs.map((faq) => (
+          <details key={faq.question}>
+            <summary>{faq.question}</summary>
+            <p>{faq.answer}</p>
+          </details>
+        ))}
+      </main>
+    </>
+  );
+}
+```
+
+## Programmatic JSON-LD access
+
+```ts
+import { seoConfig } from "@/lib/seo";
+
+// Get all JSON-LD as objects
+const schemas = seoConfig.getJsonLd();
+
+// Get with additional schemas merged in
+const allSchemas = seoConfig.getJsonLd([extraSchema]);
+
+// Get as stringified JSON (for manual <script> injection)
+const jsonStrings = seoConfig.getJsonLdStrings();
+```

--- a/packages/seox/docs/getting-started.md
+++ b/packages/seox/docs/getting-started.md
@@ -1,0 +1,113 @@
+# Getting started
+
+## Installation
+
+```bash
+bun add seox
+# or: npm install seox / pnpm add seox / yarn add seox
+```
+
+## Step 1: Create your SEO config
+
+Create a file `lib/seo.ts` (or run `bunx seox init` for interactive setup):
+
+```ts
+import { Seox } from "seox/next";
+
+export const seoConfig = new Seox({
+  name: "My Site",
+  url: "https://mysite.com",
+  metadataBase: new URL("https://mysite.com"),
+  title: {
+    default: "My Site - Tagline",
+    template: "%s | My Site",
+  },
+  description: "A description of my site",
+  keywords: ["nextjs", "seo"],
+  creator: "Author Name",
+  publisher: "Author Name",
+  authors: [{ name: "Author Name", url: "https://mysite.com" }],
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "My Site",
+  },
+  twitter: {
+    card: "summary_large_image",
+    creator: "@handle",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  jsonld: [
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      name: "My Site",
+      url: "https://mysite.com",
+    },
+  ],
+});
+```
+
+`SEOConfig` extends Next.js `Metadata`, so all standard metadata fields are supported. The additional fields are `name`, `url`, and `jsonld`.
+
+## Step 2: Apply metadata to your root layout
+
+```tsx
+// app/layout.tsx
+import { seoConfig } from "@/lib/seo";
+import { JsonLd } from "seox/next";
+
+export const metadata = seoConfig.configToMetadata();
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <JsonLd seo={seoConfig} />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+This single call generates all `<title>`, `<meta>`, Open Graph, and Twitter Card tags through Next.js built-in metadata system.
+
+## Step 3: Override per page
+
+```tsx
+// app/about/page.tsx
+import { seoConfig } from "@/lib/seo";
+
+export const metadata = seoConfig.configToMetadata({
+  title: "About Us",
+  description: "Learn more about our team",
+  openGraph: {
+    title: "About Us - My Site",
+  },
+});
+
+export default function AboutPage() {
+  return <main>About content</main>;
+}
+```
+
+Overrides are deep-merged with the base configuration. The `title` value uses the template defined in your config (e.g. `"About Us | My Site"`).
+
+## Step 4: Verify with doctor
+
+```bash
+bunx seox doctor
+```
+
+This validates your config file exists and checks for common SEO issues (missing title, description, invalid URL, etc.).

--- a/packages/seox/package.json
+++ b/packages/seox/package.json
@@ -7,7 +7,8 @@
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"files": [
-		"dist"
+		"dist",
+		"docs"
 	],
 	"bin": {
 		"seox": "./dist/cli.js"


### PR DESCRIPTION
This pull request introduces comprehensive documentation and supporting utilities for the new `seox` library, which provides centralized SEO management for Next.js App Router projects. The changes include detailed user and API documentation, CLI usage guides, practical examples, and supporting code for enhanced documentation rendering and content negotiation. Additionally, the package is updated to include the documentation files in published builds.

Documentation for `seox`:

* Added a thorough `README.md` describing the library's purpose, exports, and requirements.
* Added `getting-started.md` with installation instructions and step-by-step setup guide.
* Added `api-reference.md` detailing types, the `Seox` class, methods, and the `JsonLd` component.
* Added `cli.md` covering all CLI commands (`init`, `configure`, `doctor`) with explanations and options.
* Added `examples.md` with practical usage scenarios for blogs, product pages, FAQ pages, and programmatic API usage.

Documentation build and content negotiation support:

* Added `get-llm-text.ts` utility for extracting and formatting processed documentation text for LLMs.
* Added `proxy.ts` to handle content negotiation, rewriting requests to serve LLM-friendly markdown when preferred.

Package publishing:

* Updated `package.json` to include the `docs` directory in the published package files.